### PR TITLE
fix oembed routes by adding a /public api root

### DIFF
--- a/Instagram.php
+++ b/Instagram.php
@@ -20,6 +20,7 @@ class Instagram {
    * The API base URL
    */
   const API_URL = 'https://api.instagram.com/v1/';
+  const API_PUBLIC_URL = 'https://api.instagram.com/public/';
 
   /**
    * The API OAuth URL
@@ -392,7 +393,7 @@ class Instagram {
    * @return mixed
    */
   public function getoEmbed($url) {
-    return $this->_makeCall( '/oembed?url='.urlencode($url) );
+    return $this->_makeCall( '/oembed', 'public', ['url' => $url] );
   }
 
   /**
@@ -453,7 +454,7 @@ class Instagram {
    * @return mixed
    */
   protected function _makeCall($function, $auth = false, $params = null, $method = 'GET') {
-    if (false === $auth) {
+    if (false === $auth || 'public' === $auth) {
       // if the call doesn't requires authentication
       $authMethod = '?client_id=' . $this->getApiKey();
     } else {
@@ -471,7 +472,8 @@ class Instagram {
       $paramString = null;
     }
 
-    $apiCall = self::API_URL . $function . $authMethod . (('GET' === $method) ? $paramString : null);
+    $apiUrl = $auth == 'public' ? self::API_PUBLIC_URL : self::API_URL;
+    $apiCall = $apiUrl . $function . $authMethod . (('GET' === $method) ? $paramString : null);
 
     // signed header of POST/DELETE requests
     $headerData = array('Accept: application/json');
@@ -495,6 +497,7 @@ class Instagram {
     }
 
     $jsonData = curl_exec($ch);
+
     if (false === $jsonData) {
       throw new \Exception("Error: _makeCall() - cURL error: " . curl_error($ch));
     }


### PR DESCRIPTION
The plugin seems to be broken because it can't load the oembed endpoint.

In the Instagram API, /oembed only exists at the root and under public, i.e., `https://api.instagram.com/oembed` or `https://api.instagram.com/public/oembed`. The version of Instagram-PHP-API being used by acf-field-instagram tries to load oembed data from `https://api.instagram.com/v1/oembed`.

This fix allows `public` to be passed to `_makeCall` for the `$auth` value, at which point it will swap `API_URL` for `API_PUBLIC_URL` and proceed as usual.
